### PR TITLE
Workaround model sync

### DIFF
--- a/source/ignition_live/FUSDNoticeListener.hpp
+++ b/source/ignition_live/FUSDNoticeListener.hpp
@@ -257,26 +257,34 @@ class FUSDNoticeListener : public pxr::TfWeakBase
           transforms.scale += visualOp.scale;
         }
         auto currentPrimName = currentPrim.GetName().GetString();
-        if (currentPrimName.substr(currentPrimName.size() -
-                                   std::string("_visual").size()) == "_visual")
+        int substrIndex = currentPrimName.size() - std::string("_visual").size();
+        if (substrIndex >= 0 && substrIndex < currentPrimName.size())
         {
-          currentPrim = currentPrim.GetParent();
-          auto linkXform = pxr::UsdGeomXformable(currentPrim);
-          auto linkOp = GetOp(linkXform);
-          transforms.position += linkOp.position;
-          transforms.rotXYZ += linkOp.rotXYZ;
-          transforms.scale += linkOp.scale;
+          if (currentPrimName.substr(substrIndex).find("_visual") !=
+            std::string::npos)
+          {
+            currentPrim = currentPrim.GetParent();
+            auto linkXform = pxr::UsdGeomXformable(currentPrim);
+            auto linkOp = GetOp(linkXform);
+            transforms.position += linkOp.position;
+            transforms.rotXYZ += linkOp.rotXYZ;
+            transforms.scale += linkOp.scale;
+          }
         }
         currentPrimName = currentPrim.GetName().GetString();
-        if (currentPrimName.substr(currentPrimName.size() -
-                                   std::string("_link").size()) == "_link")
+        substrIndex = currentPrimName.size() - std::string("_link").size();
+        if (substrIndex >= 0 && substrIndex < currentPrimName.size())
         {
-          currentPrim = currentPrim.GetParent();
-          auto modelXform = pxr::UsdGeomXformable(currentPrim);
-          auto modelOp = GetOp(modelXform);
-          transforms.position += modelOp.position;
-          transforms.rotXYZ += modelOp.rotXYZ;
-          transforms.scale += modelOp.scale;
+          if (currentPrimName.substr(substrIndex).find("_link") !=
+              std::string::npos)
+          {
+            currentPrim = currentPrim.GetParent();
+            auto modelXform = pxr::UsdGeomXformable(currentPrim);
+            auto modelOp = GetOp(modelXform);
+            transforms.position += modelOp.position;
+            transforms.rotXYZ += modelOp.rotXYZ;
+            transforms.scale += modelOp.scale;
+          }
         }
 
         // Prepare the input parameters.

--- a/source/ignition_live/Scene.cpp
+++ b/source/ignition_live/Scene.cpp
@@ -151,7 +151,7 @@ bool Scene::Implementation::UpdateVisual(const ignition::msgs::Visual &_visual,
 {
   auto stage = this->stage->Lock();
 
-  std::string usdVisualPath = _usdLinkPath + "/" + _visual.name();
+  std::string usdVisualPath = _usdLinkPath + "/" + _visual.name() + "_visual";
   auto usdVisualXform =
       pxr::UsdGeomXform::Define(*stage, pxr::SdfPath(usdVisualPath));
   pxr::UsdGeomXformCommonAPI xformApi(usdVisualXform);
@@ -350,7 +350,7 @@ bool Scene::Implementation::UpdateLink(const ignition::msgs::Link &_link,
                                        const std::string &_usdModelPath)
 {
   auto stage = this->stage->Lock();
-  std::string usdLinkPath = _usdModelPath + "/" + _link.name();
+  std::string usdLinkPath = _usdModelPath + "/" + _link.name() + "_link";
   auto xform = pxr::UsdGeomXform::Define(*stage, pxr::SdfPath(usdLinkPath));
   pxr::UsdGeomXformCommonAPI xformApi(xform);
 


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary

isaacsim/usd is much more flexible than ignition/sdf. It allows almost any prim to have transformations, changing the transformation of a prim that matches a non-transformable node in ignition causes errors.

The main downside to this workaround is that it makes an assumption on the scene graph of the usd. This means that it only works for usd generated by the connector, usd from other applications (including isaac sim) will not work. Actually this is already the case as the connector assumes the prims are named according to the sdf, this PR just makes the limitation more apparent.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.